### PR TITLE
when handling embedded replace line, pass all parts

### DIFF
--- a/pkg/mod.go
+++ b/pkg/mod.go
@@ -104,7 +104,7 @@ func ParseMod(r io.Reader) (*ModFile, error) {
 				}
 				m.Requires = append(m.Requires, entry)
 			case inReplace:
-				old, replace, err := replaceEntry(parts[1:])
+				old, replace, err := replaceEntry(parts)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
There are two cases for a `replace` line.

* single line
* embedded

### Single line

When the replace is a single line, i.e.

```go
 replace abc => something_else v1.2.3
```

it handles it correctly by calling `replaceEntry(parts[1:])`, i.e. everything except for the `replace` word.

### Multi-line

When the replace is multi-line embedded, i.e.

```
replace (
    abc => something_else v1.2.3
)
```

It _still_ passes `replaceEntry(parts[1:])`, which is a mistake, as you miss the `abc` part. This fixes it to `replaceEntry(parts)`.

